### PR TITLE
Refactor criar pedido

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,11 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "luxon": "^3.4.4",
-        "mercadopago": "2.0.6",
         "pg": "^8.11.3",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
-        "typeorm": "^0.3.17"
+        "typeorm": "^0.3.17",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@faker-js/faker": "^8.4.1",
@@ -38,6 +38,7 @@
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
         "@types/supertest": "^2.0.12",
+        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.42.0",
@@ -2472,6 +2473,14 @@
         "reflect-metadata": "^0.1.13"
       }
     },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.3.0.tgz",
@@ -2635,18 +2644,6 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
-      }
-    },
-    "node_modules/@nestjs/typeorm/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3602,6 +3599,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.11.8",
@@ -7821,15 +7824,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/mercadopago": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/mercadopago/-/mercadopago-2.0.6.tgz",
-      "integrity": "sha512-+lFz8ZtsGrMMfsFaQWhCcDk6I7NgvwyALLKbtPNF6Z7fgaao1yHSc+22KppKZyAqQronWAOHQ+mOhWQkO1/mHQ==",
-      "dependencies": {
-        "node-fetch": "^2.6.12",
-        "uuid": "^9.0.0"
-      }
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -10344,9 +10338,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "luxon": "^3.4.4",
-    "mercadopago": "2.0.6",
     "pg": "^8.11.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
@@ -49,6 +49,7 @@
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.42.0",

--- a/src/application/use_cases/pedido/pedido.use_case.spec.ts
+++ b/src/application/use_cases/pedido/pedido.use_case.spec.ts
@@ -23,6 +23,7 @@ import {
 } from 'src/mocks/cliente.mock';
 import { IClienteRepository } from 'src/domain/cliente/interfaces/cliente.repository.port';
 import { IPagamentoService } from 'src/domain/pedido/interfaces/pagamento.service.port';
+import { StatusPagamento } from 'src/domain/pedido/enums/pedido.enum';
 
 describe('PedidoUseCase', () => {
   let pedidoUseCase: PedidoUseCase;
@@ -118,14 +119,14 @@ describe('PedidoUseCase', () => {
   });
 
   it('deve editar o status de um pedido e pagamento com sucesso', async () => {
-    atualizaPedidoDTOMock.pago = true;
+    atualizaPedidoDTOMock.statusPagamento = StatusPagamento.PAGO;
 
     const pedidoModelPagoMock = pedidoModelMock;
     pedidoModelPagoMock.statusPedido = 'em_preparacao';
-    pedidoModelPagoMock.pago = true;
+    pedidoModelPagoMock.statusPagamento = 'pago';
 
     pedidoDTOMock.statusPedido = 'em_preparacao';
-    pedidoDTOMock.pago = true;
+    pedidoDTOMock.statusPagamento = 'pago';
 
     pedidoRepositoryMock.buscarPedido.mockReturnValue(pedidoModelMock);
     pedidoRepositoryMock.editarStatusPagamento.mockReturnValue(
@@ -144,7 +145,7 @@ describe('PedidoUseCase', () => {
     expect(pedidoRepositoryMock.buscarPedido).toHaveBeenCalledWith(pedidoId);
     expect(pedidoRepositoryMock.editarStatusPagamento).toHaveBeenCalledWith(
       pedidoId,
-      atualizaPedidoDTOMock.pago,
+      atualizaPedidoDTOMock.statusPagamento,
     );
     expect(pedidoRepositoryMock.editarStatusPedido).toHaveBeenCalledWith(
       pedidoId,

--- a/src/application/use_cases/pedido/pedido.use_case.ts
+++ b/src/application/use_cases/pedido/pedido.use_case.ts
@@ -73,10 +73,10 @@ export class PedidoUseCase implements IPedidoUseCase {
       await this.criarOuAtualizarCliente(cliente);
     pedido.cliente = clienteCriadoOuAtualizado;
     pedido.clientePedido = this.copiarDadosCliente(clienteCriadoOuAtualizado);
+
+    const pagamentoQRCode = await this.pagamentoService.gerarPagamento(pedido);
     const pedidoCriado = await this.pedidoRepository.criarPedido(pedido);
     const pedidoDTO = this.pedidoDTOFactory.criarPedidoDTO(pedidoCriado);
-    const pagamentoQRCode =
-      await this.pagamentoService.gerarPagamento(pedidoCriado);
     pedidoDTO.qrCode = pagamentoQRCode.qrCode;
     return {
       mensagem: 'Pedido criado com sucesso',
@@ -126,10 +126,10 @@ export class PedidoUseCase implements IPedidoUseCase {
   ): Promise<HTTPResponse<PedidoDTO>> {
     await this.validarPedidoPorId(idPedido);
 
-    if (atualizaPedidoDTO.pago !== undefined) {
+    if (atualizaPedidoDTO.statusPagamento !== undefined) {
       await this.pedidoRepository.editarStatusPagamento(
         idPedido,
-        atualizaPedidoDTO.pago,
+        atualizaPedidoDTO.statusPagamento,
       );
     }
 

--- a/src/domain/pedido/entities/pedido.entity.spec.ts
+++ b/src/domain/pedido/entities/pedido.entity.spec.ts
@@ -1,6 +1,6 @@
 import { PedidoEntity } from './pedido.entity';
 import { ItemPedidoEntity } from './item_pedido.entity';
-import { StatusPedido } from '../enums/pedido.enum';
+import { StatusPagamento, StatusPedido } from '../enums/pedido.enum';
 import { ClienteEntity } from 'src/domain/cliente/entities/cliente.entity';
 import { itemPedidoEntityMock } from 'src/mocks/item_pedido.mock';
 import { clienteEntityMock } from 'src/mocks/cliente.mock';
@@ -9,7 +9,7 @@ describe('PedidoEntity', () => {
   let itensPedido: ItemPedidoEntity[];
   let statusPedido: StatusPedido;
   let numeroPedido: string;
-  let pago: boolean;
+  let statusPagamento: StatusPagamento;
   let cliente: ClienteEntity;
   let clientePedido: ClienteEntity;
   let id: string;
@@ -17,9 +17,9 @@ describe('PedidoEntity', () => {
   beforeEach(() => {
     // Defina as variáveis antes de cada teste
     itensPedido = [itemPedidoEntityMock];
-    statusPedido = StatusPedido.RECEBIDO;
+    statusPedido = StatusPedido.AGUARDANDO_PAGAMENTO;
     numeroPedido = '05012024';
-    pago = false;
+    statusPagamento = StatusPagamento.PENDENTE;
     cliente = clienteEntityMock;
     clientePedido = clienteEntityMock;
     id = '0a14aa4e-75e7-405f-8301-81f60646c93d';
@@ -30,16 +30,16 @@ describe('PedidoEntity', () => {
       itensPedido,
       statusPedido,
       numeroPedido,
-      pago,
+      statusPagamento,
+      id,
       cliente,
       clientePedido,
-      id,
     );
 
     expect(pedido.itensPedido).toEqual(itensPedido);
     expect(pedido.statusPedido).toEqual(statusPedido);
     expect(pedido.numeroPedido).toEqual(numeroPedido);
-    expect(pedido.pago).toEqual(pago);
+    expect(pedido.statusPagamento).toEqual(statusPagamento);
     expect(pedido.cliente).toEqual(cliente);
     expect(pedido.id).toEqual(id);
   });
@@ -49,13 +49,13 @@ describe('PedidoEntity', () => {
       itensPedido,
       statusPedido,
       numeroPedido,
-      pago,
+      statusPagamento,
     );
 
     expect(pedido.itensPedido).toEqual(itensPedido);
     expect(pedido.statusPedido).toEqual(statusPedido);
     expect(pedido.numeroPedido).toEqual(numeroPedido);
-    expect(pedido.pago).toEqual(pago);
+    expect(pedido.statusPagamento).toEqual(statusPagamento);
     expect(pedido.cliente).toBeUndefined();
     expect(pedido.id).toBeUndefined();
   });

--- a/src/domain/pedido/entities/pedido.entity.ts
+++ b/src/domain/pedido/entities/pedido.entity.ts
@@ -1,15 +1,15 @@
 import { ClienteEntity } from 'src/domain/cliente/entities/cliente.entity';
-import { StatusPedido } from '../enums/pedido.enum';
+import { StatusPagamento, StatusPedido } from '../enums/pedido.enum';
 import { ItemPedidoEntity } from './item_pedido.entity';
 
 export class PedidoEntity {
   private _itensPedido: ItemPedidoEntity[];
   private _statusPedido: StatusPedido;
   private _numeroPedido: string;
-  private _pago: boolean;
+  private _statusPagamento: StatusPagamento;
+  private _id?: string;
   private _cliente?: ClienteEntity;
   private _clientePedido?: ClienteEntity;
-  private _id?: string;
   private _criadoEm?: string;
   private _atualizadoEm?: string;
 
@@ -17,16 +17,16 @@ export class PedidoEntity {
     itensPedido: ItemPedidoEntity[],
     statusPedido: StatusPedido,
     numeroPedido: string,
-    pago: boolean,
+    statusPagamento: StatusPagamento,
+    id?: string,
     cliente?: ClienteEntity,
     clientePedido?: ClienteEntity,
-    id?: string,
     criadoEm?: string,
     atualizadoEm?: string,
   ) {
     this.id = id;
     this.numeroPedido = numeroPedido;
-    this.pago = pago;
+    this.statusPagamento = statusPagamento;
     this.itensPedido = itensPedido;
     this.cliente = cliente;
     this.clientePedido = clientePedido;
@@ -59,12 +59,12 @@ export class PedidoEntity {
     this._numeroPedido = numeroPedido;
   }
 
-  get pago(): boolean {
-    return this._pago;
+  get statusPagamento(): StatusPagamento {
+    return this._statusPagamento;
   }
 
-  set pago(pago: boolean) {
-    this._pago = pago;
+  set statusPagamento(statusPagamento: StatusPagamento) {
+    this._statusPagamento = statusPagamento;
   }
 
   get cliente(): ClienteEntity | undefined {

--- a/src/domain/pedido/factories/pedido.dto.factory.ts
+++ b/src/domain/pedido/factories/pedido.dto.factory.ts
@@ -36,7 +36,7 @@ export class PedidoDTOFactory implements IPedidoDTOFactory {
     pedidoDTO.id = pedido.id;
     pedidoDTO.numeroPedido = pedido.numeroPedido;
     pedidoDTO.itensPedido = itensPedido;
-    pedidoDTO.pago = pedido.pago;
+    pedidoDTO.statusPagamento = pedido.statusPagamento;
     pedidoDTO.statusPedido = pedido.statusPedido;
     pedidoDTO.criadoEm = pedido.criadoEm;
     pedidoDTO.atualizadoEm = pedido.atualizadoEm;

--- a/src/domain/pedido/factories/pedido.factory.spec.ts
+++ b/src/domain/pedido/factories/pedido.factory.spec.ts
@@ -65,6 +65,7 @@ describe('PedidoFactory', () => {
     );
 
     const result = await pedidoFactory.criarEntidadePedido(criaPedidoDTOMock);
+    pedidoEntityNotIdMock.id = result.id;
 
     expect(pedidoServiceMock.gerarNumeroPedido).toHaveBeenCalled();
     expect(produtoRepositoryMock.buscarProdutoPorId).toHaveBeenCalled();

--- a/src/domain/pedido/factories/pedido.factory.ts
+++ b/src/domain/pedido/factories/pedido.factory.ts
@@ -10,8 +10,9 @@ import { ClienteEntity } from 'src/domain/cliente/entities/cliente.entity';
 import { ClienteNaoLocalizadoErro } from 'src/domain/cliente/exceptions/cliente.exception';
 import { CriaPedidoDTO } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
 import { PedidoEntity } from '../entities/pedido.entity';
-import { StatusPedido } from '../enums/pedido.enum';
+import { StatusPagamento, StatusPedido } from '../enums/pedido.enum';
 import { ClienteDTO } from 'src/presentation/rest/v1/presenters/cliente/cliente.dto';
+import { v4 as uuid4 } from 'uuid';
 
 @Injectable()
 export class PedidoFactory implements IPedidoFactory {
@@ -70,9 +71,10 @@ export class PedidoFactory implements IPedidoFactory {
 
     return new PedidoEntity(
       itensPedido,
-      StatusPedido.RECEBIDO,
+      StatusPedido.AGUARDANDO_PAGAMENTO,
       numeroPedido,
-      false,
+      StatusPagamento.PENDENTE,
+      uuid4(),
     );
   }
 }

--- a/src/domain/pedido/interfaces/pagamento.response.port.ts
+++ b/src/domain/pedido/interfaces/pagamento.response.port.ts
@@ -16,6 +16,6 @@ export interface PagamentoResponse {
       };
     };
   }[];
-  pago: boolean;
+  statusPagamento: string;
   StatusPedido: string;
 }

--- a/src/domain/pedido/interfaces/pedido.repository.port.ts
+++ b/src/domain/pedido/interfaces/pedido.repository.port.ts
@@ -9,7 +9,7 @@ export interface IPedidoRepository {
   ): Promise<PedidoEntity | null>;
   editarStatusPagamento(
     pedidoId: string,
-    statusPagamento: boolean,
+    statusPagamento: string,
   ): Promise<PedidoEntity | null>;
   listarPedidos(): Promise<PedidoEntity[] | []>;
   listarPedidosRecebido(): Promise<PedidoEntity[] | []>;

--- a/src/infrastructure/sql/factories/sql.dto.factory.ts
+++ b/src/infrastructure/sql/factories/sql.dto.factory.ts
@@ -7,7 +7,10 @@ import { ClienteModel } from '../models/cliente.model';
 import { ClienteEntity } from 'src/domain/cliente/entities/cliente.entity';
 import { PedidoModel } from '../models/pedido.model';
 import { PedidoEntity } from 'src/domain/pedido/entities/pedido.entity';
-import { StatusPedido } from 'src/domain/pedido/enums/pedido.enum';
+import {
+  StatusPagamento,
+  StatusPedido,
+} from 'src/domain/pedido/enums/pedido.enum';
 import { ItemPedidoEntity } from 'src/domain/pedido/entities/item_pedido.entity';
 import { ClientePedidoModel } from '../models/cliente_pedido.model';
 
@@ -78,7 +81,7 @@ export class SQLDTOFactory {
       itensPedido,
       pedido.statusPedido as StatusPedido,
       pedido.numeroPedido,
-      pedido.pago,
+      pedido.statusPagamento as StatusPagamento,
       clienteEntity,
       clientePedidoEntity,
       pedido.id,

--- a/src/infrastructure/sql/factories/sql.dto.factory.ts
+++ b/src/infrastructure/sql/factories/sql.dto.factory.ts
@@ -82,9 +82,9 @@ export class SQLDTOFactory {
       pedido.statusPedido as StatusPedido,
       pedido.numeroPedido,
       pedido.statusPagamento as StatusPagamento,
+      pedido.id,
       clienteEntity,
       clientePedidoEntity,
-      pedido.id,
       pedido.criadoEm,
       pedido.atualizadoEm,
     );

--- a/src/infrastructure/sql/models/pedido.model.ts
+++ b/src/infrastructure/sql/models/pedido.model.ts
@@ -34,8 +34,8 @@ export class PedidoModel {
   @JoinColumn({ name: 'id_cliente_pedido' })
   clientePedido: ClientePedidoModel | null;
 
-  @Column({ name: 'pago', nullable: false })
-  pago: boolean;
+  @Column({ name: 'status_pagamento', nullable: false })
+  statusPagamento: string;
 
   @Column({ name: 'status_pedido', length: 20, nullable: false })
   statusPedido: string;

--- a/src/infrastructure/sql/repositories/pedido/pedido.repository.spec.ts
+++ b/src/infrastructure/sql/repositories/pedido/pedido.repository.spec.ts
@@ -105,7 +105,7 @@ describe('PedidoRepository', () => {
   });
 
   it('deve alterar o status de pagamento do pedido', async () => {
-    const novoStatusPagamento = true;
+    const novoStatusPagamento = 'pago';
 
     pedidoTypeORMMock.findOne.mockResolvedValue(
       Promise.resolve(pedidoModelMock),
@@ -119,7 +119,7 @@ describe('PedidoRepository', () => {
     );
 
     expect(pedidoTypeORMMock.update).toHaveBeenCalledWith(pedidoId, {
-      pago: novoStatusPagamento,
+      statusPagamento: novoStatusPagamento,
     });
     expect(pedidoTypeORMMock.findOne).toHaveBeenCalledWith({
       where: { id: pedidoId },

--- a/src/infrastructure/sql/repositories/pedido/pedido.repository.ts
+++ b/src/infrastructure/sql/repositories/pedido/pedido.repository.ts
@@ -70,10 +70,10 @@ export class PedidoRepository implements IPedidoRepository {
 
   async editarStatusPagamento(
     pedidoId: string,
-    statusPagamento: boolean,
+    statusPagamento: string,
   ): Promise<PedidoEntity> {
     await this.pedidoRepository.update(pedidoId, {
-      pago: statusPagamento,
+      statusPagamento: statusPagamento,
     });
 
     const pedidoModelAtualizado = await this.pedidoRepository.findOne({

--- a/src/mocks/pedido.mock.ts
+++ b/src/mocks/pedido.mock.ts
@@ -12,7 +12,10 @@ import {
 } from './item_pedido.mock';
 import { PedidoModel } from 'src/infrastructure/sql/models/pedido.model';
 import { PedidoEntity } from 'src/domain/pedido/entities/pedido.entity';
-import { StatusPedido } from 'src/domain/pedido/enums/pedido.enum';
+import {
+  StatusPagamento,
+  StatusPedido,
+} from 'src/domain/pedido/enums/pedido.enum';
 import {
   AtualizaPedidoDTO,
   CriaPedidoDTO,
@@ -25,20 +28,20 @@ pedidoModelMock.id = '0a14aa4e-75e7-405f-8301-81f60646c93d';
 pedidoModelMock.numeroPedido = '05012024';
 pedidoModelMock.itensPedido = [itemPedidoModelMock];
 pedidoModelMock.cliente = clienteModelMock;
-pedidoModelMock.pago = false;
-pedidoModelMock.statusPedido = 'recebido';
+pedidoModelMock.statusPagamento = 'pendente';
+pedidoModelMock.statusPedido = 'aguardando_pagamento';
 pedidoModelMock.criadoEm = '2024-01-25T00:05:04.941Z';
 pedidoModelMock.atualizadoEm = '2024-01-25T00:05:04.941Z';
 
 // Mock para simular dados da entidade pedido com todos os itens
 export const pedidoEntityMock = new PedidoEntity(
   [itemPedidoEntityMock],
-  StatusPedido.RECEBIDO,
+  StatusPedido.AGUARDANDO_PAGAMENTO,
   '05012024',
-  false,
-  clienteEntityMock,
-  clienteEntityMock,
+  StatusPagamento.PENDENTE,
   '0a14aa4e-75e7-405f-8301-81f60646c93d',
+  clienteEntityMock,
+  clienteEntityMock,
   '2024-01-25T00:05:04.941Z',
   '2024-01-25T00:05:04.941Z',
 );
@@ -46,28 +49,28 @@ export const pedidoEntityMock = new PedidoEntity(
 // Mock para simular dados da entidade pedido sem data criação e atualização
 export const pedidoEntityNotDateMock = new PedidoEntity(
   [itemPedidoEntityMock],
-  StatusPedido.RECEBIDO,
+  StatusPedido.AGUARDANDO_PAGAMENTO,
   '05012024',
-  false,
-  clienteEntityMock,
-  clienteEntityMock,
+  StatusPagamento.PENDENTE,
   '0a14aa4e-75e7-405f-8301-81f60646c93d',
+  clienteEntityMock,
+  clienteEntityMock,
 );
 
 // Mock para simular dados da entidade pedido sem id
 export const pedidoEntityNotIdMock = new PedidoEntity(
   [itemPedidoEntityNotIdMock],
-  StatusPedido.RECEBIDO,
+  StatusPedido.AGUARDANDO_PAGAMENTO,
   '05012024',
-  false,
+  StatusPagamento.PENDENTE,
 );
 
 // Mock para simular dados da entidade pedido sem cliente
 export const pedidoEntityNotClienteMock = new PedidoEntity(
   [itemPedidoEntityMock],
-  StatusPedido.RECEBIDO,
+  StatusPedido.AGUARDANDO_PAGAMENTO,
   '05012024',
-  false,
+  StatusPagamento.PENDENTE,
 );
 
 // Mock para simular o DTO com os dados recebidos pelo usuario ao criar um pedido
@@ -86,12 +89,12 @@ export const pedidoDTOMock = new PedidoDTO();
 pedidoDTOMock.id = pedidoModelMock.id;
 pedidoDTOMock.numeroPedido = pedidoModelMock.numeroPedido;
 pedidoDTOMock.itensPedido = [itemPedidoDTOMock];
-pedidoDTOMock.pago = false;
+pedidoDTOMock.statusPagamento = pedidoModelMock.statusPagamento;
 pedidoDTOMock.statusPedido = pedidoModelMock.statusPedido;
 pedidoDTOMock.criadoEm = '2024-01-25T00:05:04.941Z';
 pedidoDTOMock.atualizadoEm = '2024-01-25T00:05:04.941Z';
 pedidoDTOMock.cliente = clienteDTOMock;
-pedidoDTOMock.qrCode = null;
+pedidoDTOMock.qrCode = '00020101021243650016COM';
 
 export const pagamentoResponseMock = {
   qrCode: '00020101021243650016COM',
@@ -111,8 +114,8 @@ export const pagamentoResponseMock = {
       },
     },
   },
-  pago: false,
-  statusPedido: 'recebido',
+  statusPagamento: 'pendente',
+  statusPedido: 'aguardando_pagamento',
 };
 
 // Mock jest das funções do typeORM interagindo com a tabela pedido

--- a/src/mocks/pedido.mock.ts
+++ b/src/mocks/pedido.mock.ts
@@ -94,7 +94,7 @@ pedidoDTOMock.statusPedido = pedidoModelMock.statusPedido;
 pedidoDTOMock.criadoEm = '2024-01-25T00:05:04.941Z';
 pedidoDTOMock.atualizadoEm = '2024-01-25T00:05:04.941Z';
 pedidoDTOMock.cliente = clienteDTOMock;
-pedidoDTOMock.qrCode = '00020101021243650016COM';
+pedidoDTOMock.qrCode = null;
 
 export const pagamentoResponseMock = {
   qrCode: '00020101021243650016COM',

--- a/src/presentation/rest/v1/presenters/pedido/pedido.dto.ts
+++ b/src/presentation/rest/v1/presenters/pedido/pedido.dto.ts
@@ -8,12 +8,14 @@ import {
   ArrayMinSize,
   IsDefined,
   ValidateNested,
-  IsBoolean,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { CriaItemPedidoDTO, ItemPedidoDTO } from './item_pedido.dto';
 import { ClienteDTO } from '../cliente/cliente.dto';
-import { StatusPedido } from 'src/domain/pedido/enums/pedido.enum';
+import {
+  StatusPagamento,
+  StatusPedido,
+} from 'src/domain/pedido/enums/pedido.enum';
 
 export class CriaPedidoDTO {
   @IsArray({ message: 'ItensPedido deve ser uma lista' })
@@ -49,10 +51,10 @@ export class AtualizaPedidoDTO {
   statusPedido: StatusPedido;
 
   @IsOptional()
-  @IsBoolean()
+  @IsEnum(StatusPagamento)
   @IsDefined({ each: true, message: 'O status do pagamento não pode ser nulo' })
   @ApiProperty({ description: 'Status do pagamento', required: false })
-  pago?: boolean;
+  statusPagamento?: StatusPagamento;
 }
 
 export class PedidoDTO {
@@ -79,7 +81,7 @@ export class PedidoDTO {
   atualizadoEm: string;
 
   @ApiProperty({ description: 'Status do pagamento' })
-  pago: boolean;
+  statusPagamento: string;
 
   @ApiProperty({ description: 'Cliente associado ao pedido', type: ClienteDTO })
   cliente: ClienteDTO;


### PR DESCRIPTION
- Alterado status pedido para aguardando_pagamento na criação de um novo pedido,
- Alterado o formato de status pagamento de boolean para enum StatusPagamento,
- Modificado ordem de processo dentro da criação de um pedido, sendo geração do qrcode antes de salvar o pedido no banco de dados.