### PR TITLE
refactor: renomeia services do docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Microsserviço de Pedidos do Sistema de Gestão de Restaurantes (RMS) desenvolvi
 4. Faça uma cópia do arquivo `.env.template` com o nome `.env` e preencha as variáveis de ambiente dentro dele;
 5. Execute o comando `npm install` para instalar os pacotes npm;
 6. Use o comando `npm run start` para iniciar a aplicação.
-7. Execute o comando `docker-compose up -d db` para iniciar o container do banco de dados;
+7. Execute o comando `docker-compose up -d db-pedidos` para iniciar o container do banco de dados;
 8. Acesse o Swagger em http://localhost:3000/swagger/
 
 <details>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.9'
 
 services:
-  db:
-    container_name: db
-    hostname: db
+  db-pedidos:
+    container_name: db-pedidos
+    hostname: db-pedidos
     image: postgres:16.1
     ports:
       - '5432:5432'
@@ -28,9 +28,9 @@ services:
     networks:
       - default
 
-  api:
-    container_name: api
-    hostname: api
+  api-pedidos:
+    container_name: api-pedidos
+    hostname: api-pedidos
     build:
       context: .
       dockerfile: Dockerfile
@@ -41,7 +41,7 @@ services:
     env_file:
       - .env
     environment:
-      DB_HOST: db
+      DB_HOST: db-pedidos
       DB_PORT: 5432
       DB_USER: ${DB_USERNAME:-pguser}
       DB_PASSWORD: ${DB_PASSWORD:-pgpwd}
@@ -49,17 +49,11 @@ services:
       DB_SSL: ${DB_SSL:-false}
       COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-}
       COGNITO_CLIENT_ID: ${COGNITO_CLIENT_ID:-}
-      ENABLE_MERCADOPAGO: ${ENABLE_MERCADOPAGO:-false}
-      ACCESS_TOKEN_MERCADOPAGO: ${ACCESS_TOKEN_MERCADOPAGO:-}
-      USER_ID_MERCADOPAGO: ${USER_ID_MERCADOPAGO:-}
-      EXTERNAL_POS_ID_MERCADOPAGO: ${EXTERNAL_POS_ID_MERCADOPAGO:-}
-      WEBHOOK_URL_MERCADOPAGO: ${WEBHOOK_URL_MERCADOPAGO:-}
-      IDEMPOTENCY_KEY_MERCADOPAGO: ${IDEMPOTENCY_KEY_MERCADOPAGO:-a005986e-f97c-4274-91cf-b32d2672824f}
     restart: always
     networks:
       - default
     depends_on:
-      - db
+      - db-pedidos
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db-pedidos:
     container_name: db-pedidos
     hostname: db-pedidos
-    image: postgres:16.1
+    image: postgres:15.6
     ports:
       - '5432:5432'
     expose:


### PR DESCRIPTION
Renomeando os Services dentro do `docker-compose.yaml` para que seja possível rodar mais de um microsserviço ao mesmo tempo na máquina local, sem conflitar o nome dos containers.