### PR TITLE
refactor: renomeia o bd no .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,8 @@
 DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=pguser
-DB_PASSWORD=pgpwd
-DB_NAME=rms
+DB_PASSWORD="pgpwd"
+DB_NAME=pedidos
 DB_SSL=false
 
 # Amazon Cognito

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     expose:
       - 5432
     healthcheck:
-      test: ['CMD', 'pg_isready -U ${DB_USER:-pguser} -d ${DB_NAME:-rms}']
+      test: ['CMD', 'pg_isready -U ${DB_USER:-pguser} -d ${DB_NAME:-pedidos}']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -20,7 +20,7 @@ services:
     environment:
       POSTGRES_USER: ${DB_USERNAME:-pguser}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-pgpwd}
-      POSTGRES_DB: ${DB_NAME:-rms}
+      POSTGRES_DB: ${DB_NAME:-pedidos}
       PGDATA: /data/postgres
     volumes:
       - postgres:/data/postgres


### PR DESCRIPTION
Alterando o DB_NAME dentro do arquivo `.env.template` para evitar conflitos de nomes ao executar vários microsserviços ao mesmo tempo na máquina local.