### PR TITLE
[BUG] API de Pedidos está enviando JSON com underscores _ para a API de Pagamentos

### DIFF
--- a/src/application/use_cases/pedido/pedido.use_case.spec.ts
+++ b/src/application/use_cases/pedido/pedido.use_case.spec.ts
@@ -86,7 +86,7 @@ describe('PedidoUseCase', () => {
       pedidoEntityMock,
     );
     expect(pedidoDTOFactoryMock.criarPedidoDTO).toHaveBeenCalledWith(
-      pedidoModelMock,
+      pedidoEntityMock,
     );
     expect(result).toStrictEqual({
       mensagem: 'Pedido criado com sucesso',

--- a/src/application/use_cases/pedido/pedido.use_case.ts
+++ b/src/application/use_cases/pedido/pedido.use_case.ts
@@ -74,10 +74,12 @@ export class PedidoUseCase implements IPedidoUseCase {
     pedido.cliente = clienteCriadoOuAtualizado;
     pedido.clientePedido = this.copiarDadosCliente(clienteCriadoOuAtualizado);
 
-    const pagamentoQRCode = await this.pagamentoService.gerarPagamento(pedido);
-    const pedidoCriado = await this.pedidoRepository.criarPedido(pedido);
-    const pedidoDTO = this.pedidoDTOFactory.criarPedidoDTO(pedidoCriado);
+    const pedidoDTO = this.pedidoDTOFactory.criarPedidoDTO(pedido);
+    const pagamentoQRCode =
+      await this.pagamentoService.gerarPagamento(pedidoDTO);
     pedidoDTO.qrCode = pagamentoQRCode.qrCode;
+    await this.pedidoRepository.criarPedido(pedido);
+
     return {
       mensagem: 'Pedido criado com sucesso',
       body: pedidoDTO,

--- a/src/domain/pedido/factories/pedido.factory.spec.ts
+++ b/src/domain/pedido/factories/pedido.factory.spec.ts
@@ -66,6 +66,7 @@ describe('PedidoFactory', () => {
 
     const result = await pedidoFactory.criarEntidadePedido(criaPedidoDTOMock);
     pedidoEntityNotIdMock.id = result.id;
+    itemPedidoEntityNotIdMock.id = result.itensPedido[0].id;
 
     expect(pedidoServiceMock.gerarNumeroPedido).toHaveBeenCalled();
     expect(produtoRepositoryMock.buscarProdutoPorId).toHaveBeenCalled();
@@ -78,6 +79,7 @@ describe('PedidoFactory', () => {
     const result = await pedidoFactory.criarItemPedido(
       criaPedidoDTOMock.itensPedido,
     );
+    itemPedidoEntityNotIdMock.id = result[0].id;
 
     expect(produtoRepositoryMock.buscarProdutoPorId).toHaveBeenCalledWith(
       criaPedidoDTOMock.itensPedido[0].produto,

--- a/src/domain/pedido/factories/pedido.factory.ts
+++ b/src/domain/pedido/factories/pedido.factory.ts
@@ -47,7 +47,11 @@ export class PedidoFactory implements IPedidoFactory {
           );
         }
 
-        const itemPedidoEntity = new ItemPedidoEntity(produto, item.quantidade);
+        const itemPedidoEntity = new ItemPedidoEntity(
+          produto,
+          item.quantidade,
+          uuid4(),
+        );
         return itemPedidoEntity;
       }),
     );

--- a/src/domain/pedido/interfaces/pagamento.service.port.ts
+++ b/src/domain/pedido/interfaces/pagamento.service.port.ts
@@ -1,7 +1,7 @@
-import { PedidoEntity } from '../entities/pedido.entity';
+import { PedidoDTO } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
 
 export interface IPagamentoService {
-  gerarPagamento(pedido: PedidoEntity): Promise<any>;
+  gerarPagamento(pedido: PedidoDTO): Promise<any>;
 }
 
 export const IPagamentoService = Symbol('IPagamentoService');

--- a/src/domain/pedido/services/pagamento.service.spec.ts
+++ b/src/domain/pedido/services/pagamento.service.spec.ts
@@ -3,7 +3,7 @@ import { PagamentoService } from './pagamento.service';
 import {
   pagamentoAdapterMock,
   pagamentoResponseMock,
-  pedidoEntityMock,
+  pedidoDTOMock,
 } from 'src/mocks/pedido.mock';
 import { PagamentoAdapter } from 'src/infrastructure/adapters/pagamento.adapter';
 import { ProcessarPagamentoErro } from '../exceptions/pedido.exception';
@@ -31,7 +31,7 @@ describe('PagamentoService', () => {
 
   it('deve retornar um pagamento', async () => {
     pagamentoAdapterMock.gerarPagamento.mockReturnValue(pagamentoResponseMock);
-    const pagamento = await pagamentoService.gerarPagamento(pedidoEntityMock);
+    const pagamento = await pagamentoService.gerarPagamento(pedidoDTOMock);
 
     expect(pagamento).toBe(pagamentoResponseMock);
   });
@@ -46,7 +46,7 @@ describe('PagamentoService', () => {
 
     try {
       while (tentativas < maxTentativas) {
-        await pagamentoService.gerarPagamento(pedidoEntityMock);
+        await pagamentoService.gerarPagamento(pedidoDTOMock);
         tentativas++;
       }
     } catch (error) {

--- a/src/domain/pedido/services/pagamento.service.ts
+++ b/src/domain/pedido/services/pagamento.service.ts
@@ -1,15 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { IPagamentoService } from '../interfaces/pagamento.service.port';
 import { PagamentoAdapter } from 'src/infrastructure/adapters/pagamento.adapter';
-import { PedidoEntity } from '../entities/pedido.entity';
 import { PagamentoResponse } from '../interfaces/pagamento.response.port';
 import { ProcessarPagamentoErro } from '../exceptions/pedido.exception';
+import { PedidoDTO } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
 
 @Injectable()
 export class PagamentoService implements IPagamentoService {
   constructor(private readonly pagamentoAdapter: PagamentoAdapter) {}
 
-  async gerarPagamento(pedido: PedidoEntity): Promise<PagamentoResponse> {
+  async gerarPagamento(pedido: PedidoDTO): Promise<PagamentoResponse> {
     const maxTentativas = 3;
     let tentativas = 0;
 

--- a/src/infrastructure/adapters/pagamento.adapter.spec.ts
+++ b/src/infrastructure/adapters/pagamento.adapter.spec.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PagamentoAdapter } from './pagamento.adapter';
-import { pagamentoResponseMock, pedidoEntityMock } from 'src/mocks/pedido.mock';
+import { pagamentoResponseMock, pedidoDTOMock } from 'src/mocks/pedido.mock';
 
 describe('PagamentoAdapter', () => {
   let pagamentoAdapter: PagamentoAdapter;
@@ -38,7 +38,7 @@ describe('PagamentoAdapter', () => {
       },
     });
 
-    const response = await pagamentoAdapter.gerarPagamento(pedidoEntityMock);
+    const response = await pagamentoAdapter.gerarPagamento(pedidoDTOMock);
     expect(response).toEqual(pagamentoResponseMock);
   });
 
@@ -48,7 +48,7 @@ describe('PagamentoAdapter', () => {
     jest.spyOn(axios, 'post').mockRejectedValue(new Error('Erro'));
 
     await expect(
-      pagamentoAdapter.gerarPagamento(pedidoEntityMock),
+      pagamentoAdapter.gerarPagamento(pedidoDTOMock),
     ).rejects.toThrow('Ocorreu um erro ao gerar o pagamento.');
   });
 });

--- a/src/infrastructure/adapters/pagamento.adapter.ts
+++ b/src/infrastructure/adapters/pagamento.adapter.ts
@@ -1,13 +1,13 @@
 import axios from 'axios';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { PedidoEntity } from 'src/domain/pedido/entities/pedido.entity';
 import { PagamentoResponse } from 'src/domain/pedido/interfaces/pagamento.response.port';
+import { PedidoDTO } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
 
 @Injectable()
 export class PagamentoAdapter {
   constructor(private configService: ConfigService) {}
-  async gerarPagamento(pedido: PedidoEntity): Promise<PagamentoResponse> {
+  async gerarPagamento(pedido: PedidoDTO): Promise<PagamentoResponse> {
     try {
       const response = await axios.post(
         this.configService.get<string>('URL_API_PAGAMENTOS'),


### PR DESCRIPTION
Alterado formato de envio de dados para api pagamento de pedido entity para pedido dto, assim não sera mais enviado com underscores