### PR TITLE
feat(142): Consome msg falha cobranca

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,5 +27,9 @@ REGION_FILA_NOVA_COBRANCA=us-east-1
 NOME_FILA_COBRANCA_GERADA=cobranca-gerada
 URL_FILA_COBRANCA_GERADA=http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/cobranca-gerada
 REGION_FILA_COBRANCA_GERADA=us-east-1
+# Fila de falha na cobrança
+NOME_FILA_FALHA_COBRANCA=falha-cobranca
+URL_FILA_FALHA_COBRANCA=http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/falha-cobranca
+REGION_FILA_FALHA_COBRANCA=us-east-1
 
 LOCALSTACK_ENDPOINT=http://sqs.us-east-1.localhost.localstack.cloud:4566

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,9 @@ services:
       NOME_FILA_COBRANCA_GERADA: ${NOME_FILA_COBRANCA_GERADA:-cobranca-gerada}
       URL_FILA_COBRANCA_GERADA: http://localstack:4566/000000000000/cobranca-gerada
       REGION_FILA_COBRANCA_GERADA: ${REGION_FILA_COBRANCA_GERADA:-us-east-1}
+      NOME_FILA_FALHA_COBRANCA: ${NOME_FILA_FALHA_COBRANCA:-falha-cobranca}
+      URL_FILA_FALHA_COBRANCA: http://localstack:4566/000000000000/falha-cobranca
+      REGION_FILA_FALHA_COBRANCA: ${REGION_FILA_FALHA_COBRANCA:-us-east-1}
     restart: always
     networks:
       - rms

--- a/k8s/production/api/deployment.yaml
+++ b/k8s/production/api/deployment.yaml
@@ -95,6 +95,21 @@ spec:
                 secretKeyRef:
                   name: sqs-fila-cobranca-gerada-secret
                   key: REGION_FILA_COBRANCA_GERADA
+            - name: NOME_FILA_FALHA_COBRANCA
+              valueFrom:
+                secretKeyRef:
+                  name: sqs-fila-falha-cobranca-secret
+                  key: NOME_FILA_FALHA_COBRANCA
+            - name: URL_FILA_FALHA_COBRANCA
+              valueFrom:
+                secretKeyRef:
+                  name: sqs-fila-falha-cobranca-secret
+                  key: URL_FILA_FALHA_COBRANCA
+            - name: REGION_FILA_FALHA_COBRANCA
+              valueFrom:
+                secretKeyRef:
+                  name: sqs-fila-falha-cobranca-secret
+                  key: REGION_FILA_FALHA_COBRANCA
           ports:
             - containerPort: 3002
           resources:

--- a/k8s/production/api/secret-provider.yaml
+++ b/k8s/production/api/secret-provider.yaml
@@ -42,6 +42,15 @@ spec:
           key: URL_FILA_COBRANCA_GERADA
         - objectName: REGION_FILA_COBRANCA_GERADA
           key: REGION_FILA_COBRANCA_GERADA
+    - secretName: sqs-fila-falha-cobranca-secret # Nome do Secret que será montado automaticamente contendo os segredos do AWS Secrets Manager
+      type: Opaque
+      data:
+        - objectName: NOME_FILA_FALHA_COBRANCA
+          key: NOME_FILA_FALHA_COBRANCA
+        - objectName: URL_FILA_FALHA_COBRANCA
+          key: URL_FILA_FALHA_COBRANCA
+        - objectName: REGION_FILA_FALHA_COBRANCA
+          key: REGION_FILA_FALHA_COBRANCA
   parameters:
     # Informe abaixo no campo objectName os nomes dos Segredos do AWS Secrets Manager que deseja acessar.
     # Certifique-se de que as Keys declaradas abaixo existem e estão preenchidas na AWS, caso contrário receberá o erro "Failed to fetch secret from all regions"
@@ -82,3 +91,12 @@ spec:
             objectAlias: "URL_FILA_COBRANCA_GERADA"
           - path: "QUEUE_REGION"
             objectAlias: "REGION_FILA_COBRANCA_GERADA"
+      - objectName: "prod/RMS/SQSFalhaCobranca"
+        objectType: "secretsmanager"
+        jmesPath:
+          - path: "QUEUE_NAME"
+            objectAlias: "NOME_FILA_FALHA_COBRANCA"
+          - path: "QUEUE_URL"
+            objectAlias: "URL_FILA_FALHA_COBRANCA"
+          - path: "QUEUE_REGION"
+            objectAlias: "REGION_FILA_FALHA_COBRANCA"

--- a/src/infrastructure/message_handlers/falha_cobranca/falha_cobranca.handler.spec.ts
+++ b/src/infrastructure/message_handlers/falha_cobranca/falha_cobranca.handler.spec.ts
@@ -1,0 +1,75 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { pedidoDTOMock, pedidoUseCaseMock } from 'src/mocks/pedido.mock';
+import { FalhaCobrancaMessageHandler } from './falha_cobranca.handler';
+import { IPedidoUseCase } from 'src/domain/pedido/interfaces/pedido.use_case.port';
+import { messageMock } from 'src/mocks/message.mock';
+import { Logger } from '@nestjs/common';
+import { AtualizaPedidoDTO } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
+import { StatusPedido, StatusPagamento } from 'src/domain/pedido/enums/pedido.enum';
+
+describe('FalhaCobrancaMessageHandler', () => {
+  let falhaCobrancaMessageHandler: FalhaCobrancaMessageHandler;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        Logger,
+        FalhaCobrancaMessageHandler,
+        {
+          provide: IPedidoUseCase,
+          useValue: pedidoUseCaseMock,
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+            getOrThrow: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    falhaCobrancaMessageHandler = module.get<FalhaCobrancaMessageHandler>(
+      FalhaCobrancaMessageHandler,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve consumir mensagem de falha na cobrança', async () => {
+    const HTTPResponse = {
+      mensagem: 'Pedido atualizado com sucesso',
+      body: pedidoDTOMock,
+    };
+    const atualizaPedidoDTO: AtualizaPedidoDTO = {
+      statusPedido: StatusPedido.CANCELADO,
+      statusPagamento: StatusPagamento.RECUSADO,
+    };
+    pedidoUseCaseMock.editarPedido.mockReturnValue(HTTPResponse);
+
+    await falhaCobrancaMessageHandler.handleMessage(messageMock);
+
+    expect(pedidoUseCaseMock.editarPedido).toHaveBeenCalledWith(
+      pedidoDTOMock.id,
+      atualizaPedidoDTO,
+    );
+  });
+
+  it('deve lançar exceção ao consumir mensagem de falha na cobrança', async () => {
+    const atualizaPedidoDTO: AtualizaPedidoDTO = {
+      statusPedido: StatusPedido.CANCELADO,
+      statusPagamento: StatusPagamento.RECUSADO,
+    };
+    pedidoUseCaseMock.editarPedido.mockRejectedValue(new Error('Erro'));
+
+    await falhaCobrancaMessageHandler.handleMessage(messageMock);
+
+    expect(pedidoUseCaseMock.editarPedido).toHaveBeenCalledWith(
+      pedidoDTOMock.id,
+      atualizaPedidoDTO,
+    );
+  });
+});

--- a/src/infrastructure/message_handlers/falha_cobranca/falha_cobranca.handler.ts
+++ b/src/infrastructure/message_handlers/falha_cobranca/falha_cobranca.handler.ts
@@ -2,6 +2,10 @@ import { Message } from '@aws-sdk/client-sqs';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SqsConsumerEventHandler, SqsMessageHandler } from '@ssut/nestjs-sqs';
+import {
+  StatusPagamento,
+  StatusPedido,
+} from 'src/domain/pedido/enums/pedido.enum';
 import { IPedidoUseCase } from 'src/domain/pedido/interfaces/pedido.use_case.port';
 import {
   AtualizaPedidoDTO,
@@ -9,8 +13,8 @@ import {
 } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
 
 @Injectable()
-export class CobrancaMessageHandler {
-  private _nomeFilaCobrancaGerada: string;
+export class FalhaCobrancaMessageHandler {
+  private _nomeFilaFalhaCobranca: string;
 
   constructor(
     private readonly logger: Logger,
@@ -18,45 +22,42 @@ export class CobrancaMessageHandler {
     @Inject(IPedidoUseCase)
     private readonly pedidoUseCase: IPedidoUseCase,
   ) {
-    this._nomeFilaCobrancaGerada = this.configService.getOrThrow<string>(
-      'NOME_FILA_COBRANCA_GERADA',
+    this._nomeFilaFalhaCobranca = this.configService.getOrThrow<string>(
+      'NOME_FILA_FALHA_COBRANCA',
     );
   }
 
-  @SqsMessageHandler('cobranca-gerada', false)
+  @SqsMessageHandler('falha-cobranca', false)
   public async handleMessage(message: Message) {
     this.logger.debug(
-      `Nova mensagem recebida na fila cobranca-gerada`,
+      `Nova mensagem recebida na fila falha-cobranca`,
       JSON.stringify(message),
     );
     try {
       const parsedBody: any = JSON.parse(message.Body);
       const pedidoDTO: PedidoDTO = parsedBody as unknown as PedidoDTO;
-      this.logger.log(
-        `Associando QR Code ao pedido ${pedidoDTO.id}`,
-        pedidoDTO.qrCode,
+      this.logger.warn(
+        `Cancelando o pedido ${pedidoDTO.id} devido a falha ao gerar cobrança...`,
       );
       const atualizaPedidoDTO: AtualizaPedidoDTO = {
-        qrCode: pedidoDTO.qrCode,
+        statusPedido: StatusPedido.CANCELADO,
+        statusPagamento: StatusPagamento.RECUSADO,
       };
       await this.pedidoUseCase.editarPedido(pedidoDTO.id, atualizaPedidoDTO);
+      this.logger.warn(`O pedido ${pedidoDTO.id} foi cancelado`);
     } catch (error) {
       this.logger.error(
-        `Ocorreu um erro ao processar a mensagem`,
+        `Ocorreu um erro ao processar a mensagem com MessageId ${message?.MessageId}`,
         error,
         JSON.stringify(message),
       );
     }
   }
 
-  @SqsConsumerEventHandler(
-    /** name: */ 'queueName',
-    /** eventName: */ 'processing_error',
-  )
+  @SqsConsumerEventHandler('falha-cobranca', 'processing_error')
   public onProcessingError(error: Error, message: Message) {
-    // report errors here
     this.logger.error(
-      `Ocorreu um erro ao processar a mensagem`,
+      `Ocorreu um erro ao processar a mensagem com MessageId ${message?.MessageId}`,
       error,
       JSON.stringify(message),
     );

--- a/src/infrastructure/message_handlers/nova_cobranca/nova_cobranca.handler.spec.ts
+++ b/src/infrastructure/message_handlers/nova_cobranca/nova_cobranca.handler.spec.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { pedidoDTOMock, pedidoUseCaseMock } from 'src/mocks/pedido.mock';
-import { CobrancaMessageHandler } from './cobranca.message_handler';
+import { CobrancaMessageHandler } from './nova_cobranca.handler';
 import { IPedidoUseCase } from 'src/domain/pedido/interfaces/pedido.use_case.port';
 import { messageMock } from 'src/mocks/message.mock';
 import { Logger } from '@nestjs/common';

--- a/src/infrastructure/message_handlers/nova_cobranca/nova_cobranca.handler.ts
+++ b/src/infrastructure/message_handlers/nova_cobranca/nova_cobranca.handler.ts
@@ -1,0 +1,60 @@
+import { Message } from '@aws-sdk/client-sqs';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SqsConsumerEventHandler, SqsMessageHandler } from '@ssut/nestjs-sqs';
+import { IPedidoUseCase } from 'src/domain/pedido/interfaces/pedido.use_case.port';
+import {
+  AtualizaPedidoDTO,
+  PedidoDTO,
+} from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
+
+@Injectable()
+export class CobrancaMessageHandler {
+  private _nomeFilaCobrancaGerada: string;
+
+  constructor(
+    private readonly logger: Logger,
+    private configService: ConfigService,
+    @Inject(IPedidoUseCase)
+    private readonly pedidoUseCase: IPedidoUseCase,
+  ) {
+    this._nomeFilaCobrancaGerada = this.configService.getOrThrow<string>(
+      'NOME_FILA_COBRANCA_GERADA',
+    );
+  }
+
+  @SqsMessageHandler('cobranca-gerada', false)
+  public async handleMessage(message: Message) {
+    this.logger.debug(
+      `Nova mensagem recebida na fila cobranca-gerada`,
+      JSON.stringify(message),
+    );
+    try {
+      const parsedBody: any = JSON.parse(message.Body);
+      const pedidoDTO: PedidoDTO = parsedBody as unknown as PedidoDTO;
+      this.logger.log(
+        `Associando QR Code ao pedido ${pedidoDTO.id}`,
+        pedidoDTO.qrCode,
+      );
+      const atualizaPedidoDTO: AtualizaPedidoDTO = {
+        qrCode: pedidoDTO.qrCode,
+      };
+      await this.pedidoUseCase.editarPedido(pedidoDTO.id, atualizaPedidoDTO);
+    } catch (error) {
+      this.logger.error(
+        `Ocorreu um erro ao processar a mensagem com MessageId ${message?.MessageId}`,
+        error,
+        JSON.stringify(message),
+      );
+    }
+  }
+
+  @SqsConsumerEventHandler('cobranca-gerada', 'processing_error')
+  public onProcessingError(error: Error, message: Message) {
+    this.logger.error(
+      `Ocorreu um erro ao processar a mensagem com MessageId ${message?.MessageId}`,
+      error,
+      JSON.stringify(message),
+    );
+  }
+}

--- a/src/modules/pedido.module.ts
+++ b/src/modules/pedido.module.ts
@@ -24,7 +24,8 @@ import { FilaNovaCobrancaAdapter } from 'src/infrastructure/adapters/filas/nova_
 import { SqsModule } from '@ssut/nestjs-sqs';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { SQSClient } from '@aws-sdk/client-sqs';
-import { CobrancaMessageHandler } from 'src/infrastructure/message_handlers/cobranca/cobranca.message_handler';
+import { CobrancaMessageHandler } from 'src/infrastructure/message_handlers/nova_cobranca/nova_cobranca.handler';
+import { FalhaCobrancaMessageHandler } from 'src/infrastructure/message_handlers/falha_cobranca/falha_cobranca.handler';
 
 @Module({
   imports: [
@@ -57,6 +58,23 @@ import { CobrancaMessageHandler } from 'src/infrastructure/message_handlers/cobr
                 endpoint: configService.get<string>('LOCALSTACK_ENDPOINT'),
               }),
             },
+            {
+              name: configService.getOrThrow<string>(
+                'NOME_FILA_FALHA_COBRANCA',
+              ),
+              queueUrl: configService.getOrThrow<string>(
+                'URL_FILA_FALHA_COBRANCA',
+              ),
+              region: configService.getOrThrow<string>(
+                'REGION_FILA_FALHA_COBRANCA',
+              ),
+              sqs: new SQSClient({
+                region: configService.getOrThrow<string>(
+                  'REGION_FILA_FALHA_COBRANCA',
+                ),
+                endpoint: configService.get<string>('LOCALSTACK_ENDPOINT'),
+              }),
+            },
           ],
           producers: [
             {
@@ -67,6 +85,12 @@ import { CobrancaMessageHandler } from 'src/infrastructure/message_handlers/cobr
               region: configService.getOrThrow<string>(
                 'REGION_FILA_NOVA_COBRANCA',
               ),
+              sqs: new SQSClient({
+                region: configService.getOrThrow<string>(
+                  'REGION_FILA_NOVA_COBRANCA',
+                ),
+                endpoint: configService.get<string>('LOCALSTACK_ENDPOINT'),
+              }),
             },
           ],
         };
@@ -77,8 +101,9 @@ import { CobrancaMessageHandler } from 'src/infrastructure/message_handlers/cobr
   controllers: [PedidoController],
   providers: [
     Logger,
-    PedidoUseCase,
     CobrancaMessageHandler,
+    FalhaCobrancaMessageHandler,
+    PedidoUseCase,
     {
       provide: IPedidoUseCase,
       useClass: PedidoUseCase,


### PR DESCRIPTION
Implementação da fila `falha-cobranca` de ação compensatória.

## 0
Estragando o endereço da API do Mercado Pago propositalmente para forçar uma falha ao gerar o QR Code:
<img width="563" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-api-pagamentos/assets/5115895/d8923b74-a5dd-4e78-98ea-eff5fa35b863">

## 1
<img width="1021" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-api-pagamentos/assets/5115895/14c05ee9-3623-4ff6-973c-3464744f6f93">

## 2
<img width="1001" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-api-pagamentos/assets/5115895/23ec23c1-626a-44bf-91c2-ba13548d45af">

## 3
<img width="1022" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-api-pagamentos/assets/5115895/f2c30b22-f4c3-425d-bbd9-cb072866f130">

## 4
<img width="1001" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-api-pagamentos/assets/5115895/8ab0f1a4-da9f-428e-b943-130e88ee076d">

## 5
<img width="1037" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-api-pagamentos/assets/5115895/5557046b-0e9f-4085-a543-300dd0731f4e">

<br>
<br>

Card #142 do Trello
https://trello.com/c/HGOK8xQo/142-implementar-a-fila-falha-cobranca